### PR TITLE
ci: Add CircleCI pipeline to build and test site

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,47 @@
+---
+# https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# https://circleci.com/developer/orbs/orb/circleci/hugo
+orbs:
+  hugo: circleci/hugo@1.2.2
+
+workflows:
+  main:
+    jobs:
+      - hugo/build:
+          asciidoc: true
+          html-proofer: true
+          htmlproofer-http-status-ignore: "'0,999'"
+          htmlproofer-url-ignore: "'/inventory/'"
+          htmlproofer-timeframe: "'6w'"
+          version: "latest"
+      - deploy:
+          filters:
+            branches:
+              only: main
+          requires:
+            - hugo/build
+
+jobs:
+  deploy:
+    docker:
+      - image: cibuilds/base:latest
+    working_directory: ~/hugo
+    environment:
+      HUGO_BUILD_DIR: ~/hugo/inventory-hugo-theme/public
+    steps:
+      # deploy.sh dependencies
+      - run: apk add rsync
+
+      # clone repo (required to access `.circleci/deploy.sh`)
+      - run: git clone --depth=1 https://github.com/unicef/inventory-hugo-theme.git
+
+      # checkout generated html
+      - attach_workspace:
+          at: inventory-hugo-theme
+
+      # deploy to production
+      - deploy:
+          name: Deploy to GitHub Pages
+          command: ./inventory-hugo-theme/.circleci/deploy.sh

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Force-push the built HTML to the `gh-pages` branch.
+#
+
+set -e
+
+DEPLOY_DIR=~/project
+
+# trust GitHub server keys
+mkdir ~/.ssh/
+ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+# stage generated HTML for GitHub Pages
+git clone --quiet --branch=gh-pages $CIRCLE_REPOSITORY_URL $DEPLOY_DIR
+rsync --archive --recursive --verbose --remove-source-files $HOME/hugo/inventory-hugo-theme/public/* $DEPLOY_DIR
+
+# git client setup
+cd $DEPLOY_DIR
+git config --global push.default simple
+git config --global user.email $(git --no-pager show --no-patch --format='%ae' HEAD)
+git config --global user.name $CIRCLE_USERNAME
+
+# force push to GitHub Pages
+git add --force .
+git commit --message="Deploy build $CIRCLE_BUILD_NUM [ci skip]" || true
+git push --force origin gh-pages


### PR DESCRIPTION
This commit creates a new CircleCI continuous integration pipeline to
build the example Hugo site, check that it uses valid HTML, and publish
the built site to GitHub Pages.