### PR TITLE
assets: Change color to improve accessibility

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -154,6 +154,7 @@ img {
     border: 0;
 }
 
+/* This changed this from the primary color to a darker shade to improve acessibility (https://github.com/unicef/inventory/issues/32) */
 a {
     text-decoration: none;
     color: #0076A3;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -154,11 +154,9 @@ img {
     border: 0;
 }
 
-a,
-a:hover,
-a:focus {
+a {
     text-decoration: none;
-    color: var(--primary-color);
+    color: #0076A3;
 }
 
 a:hover,


### PR DESCRIPTION
This addresses [this issue](https://github.com/unicef/inventory/issues/32) and changes the color of hyperlinks to a darker shade to help
people with visual impairmants.

Signed-off-by: Ida Delphine <mida@unicef.org>