### PR TITLE
Show icon next to sub-headings.

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -178,6 +178,19 @@ select:focus {
     outline: 0;
 }
 
+.hanchor {
+    font-size: 100%;
+    visibility: hidden;
+    color: silver;
+}
+
+h1:hover a,
+h2:hover a,
+h3:hover a,
+h4:hover a {
+    visibility: visible;
+}
+
 .slick-slide {
     outline: 0;
 }

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -24,7 +24,7 @@
           <div class="p-lg-5 p-4 bg-white">
             <h2 class="mb-5">{{ .Title }}</h2>
             {{ if .Content }}
-            <div class="content">{{.Content}}</div>
+            <div class="content">{{ partial "header-link.html" .Content }}</div>
             {{ else }}
             <div class="bg-light p-4">
               <ul class="page-list">

--- a/layouts/partials/header-link.html
+++ b/layouts/partials/header-link.html
@@ -1,0 +1,1 @@
+{{ . | replaceRE "(<h[2-9] id=\"([^\"]+)\".+)(</h[2-9]+>)" `${1}&nbsp;<a class="hanchor" href="#${2}">🔗</a> ${3}` | safeHTML }}


### PR DESCRIPTION
This is to help enable easy link sharing to specific sections of the content. It addresses [this issue](https://github.com/unicef/inventory/issues/31)