### PR TITLE
meta: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.md
+++ b/.github/ISSUE_TEMPLATE/01-bug.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: 'Is something wrong with the site theme? Open a bug report with this template.'
+labels: ['T: bug', '?: needs triage']
+assignees: ''
+
+---
+
+# Summary
+<!-- Describe the bug in one sentence. -->
+
+
+# How to reproduce?
+<!-- For example:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+1.
+2.
+3.
+
+
+# Expected behavior
+<!-- What did you expect to happen? -->
+
+
+# Actual behavior
+<!-- What actually happened? -->
+
+
+**Screenshots**:
+<!-- If it makes sense, add a screenshot or two below to show the bug. -->
+
+
+# Other details
+<!-- Add more context about the bug here. If there is nothing else, delete this section. -->
+
+

--- a/.github/ISSUE_TEMPLATE/02-improvement.md
+++ b/.github/ISSUE_TEMPLATE/02-improvement.md
@@ -1,0 +1,30 @@
+---
+name: Improvement to existing functionality
+about: 'Suggest an improvement to something that already exists.'
+labels: ['T: improvement', '?: needs triage']
+assignees: ''
+
+---
+
+# Summary
+<!-- Describe the improvement in one sentence. -->
+
+
+# Background
+<!-- Share context to why this improvement is important or why it should be completed. -->
+
+**Is the improvement related to a problem? Describe the problem**:
+
+**What does the improvement look like to you?**:
+
+**Describe any alternatives considered**:
+
+
+# Details
+<!-- Help us understand the implementation. Add specific details about the request or implementation below. Are there specific next steps to take? -->
+
+
+# Outcome
+<!-- Describe the impact of this improvement to the site in one sentence. -->
+
+

--- a/.github/ISSUE_TEMPLATE/03-new.md
+++ b/.github/ISSUE_TEMPLATE/03-new.md
@@ -1,0 +1,30 @@
+---
+name: New feature request
+about: 'Suggest a new feature or idea for something that does not exist yet.'
+labels: ['T: new change', '?: needs triage']
+assignees: ''
+
+---
+
+# Summary
+<!-- Describe the new feature in one sentence. -->
+
+
+# Background
+<!-- Share context to why this new feature is important or why it should be completed. -->
+
+**Is the new feature related to a problem? Describe the problem**:
+
+**What does the new feature look like to you?**:
+
+**Describe any alternatives considered**:
+
+
+# Details
+<!-- Help us understand the implementation. Add specific details about the new feature or implementation below. Are there specific next steps to take? -->
+
+
+# Outcome
+<!-- Describe the impact of this new feature to the site in one sentence. -->
+
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+---
+blank_issues_enabled: false
+contact_links:
+  - name: UNICEF Open Source Inventory
+    url: https://github.com/unicef/inventory
+    about: For feedback and improvements to content and information published in the UNICEF Open Source Inventory.
+  - name: UNICEF Drone DPG Toolkit
+    url: https://github.com/unicef/drone-dpgtoolkit
+    about: For feedback and improvements to content and information published in the UNICEF DPG Drone Toolkit.


### PR DESCRIPTION
This commit adds new issue templates for the Inventory Hugo theme.
Originally, I disabled issues on this repository to keep everything
together in a single repository. However, now that there are multiple
downstreams of this theme, it makes sense to use the issue tracker of
this repository to collect feedback about the design, features, and
UI/UX of the Hugo theme, separate from site-specific content.