### PR TITLE
:telephone_receiver: layouts: Add RSVP form for events

### DIFF
--- a/layouts/contact/list.html
+++ b/layouts/contact/list.html
@@ -5,7 +5,7 @@
   <div class="container">
     <div class="row">
       <div class="col-12">
-        <h2 class="section-title text-primary">{{ .Title }}</h2>
+        <h2 class="section-title text-dark">{{ .Title }}</h2>
         {{ .Content }}
         <form action="{{ .Site.Params.contact_form_action | safeURL }}" method="POST">
           <input type="text" id="name" name="name" placeholder="Name" class="form-control mb-4 shadow rounded-0">

--- a/layouts/rsvp/list.html
+++ b/layouts/rsvp/list.html
@@ -5,7 +5,7 @@
   <div class="container">
     <div class="row">
       <div class="col-12">
-        <h2 class="section-title text-primary">{{ .Title }}</h2>
+        <h2 class="section-title text-dark">{{ .Title }}</h2>
         {{ .Content }}
         <form action="{{ .Site.Params.rsvp_form.action | safeURL }}" method="POST">
           <input type="text" id="name" name="name" placeholder="Name" class="form-control mb-4 shadow rounded-0">


### PR DESCRIPTION
This commit adds a new layout for an RSVP form using the same Formspree
layout used for the contact page.

In the future, there is likely a better way to unify these as a common
layout in the event other form types are needed, but for now, this meets
the need for the Drones 4 SDG Toolkit webinar on 28 October 2021.

Related to unicef/drone-4sdgtoolkit#13.

![Example of an implementation in the Drone DPG Toolkit. This screenshot shows a RSVP form asking for name, organization, email, and what the user's background is with drones.](https://user-images.githubusercontent.com/4721034/137305329-2ff9fdf4-af67-4182-8997-c85eb6a59a03.png "Example of an implementation in the Drone DPG Toolkit. This screenshot shows a RSVP form asking for name, organization, email, and what the user's background is with drones.")