### PR TITLE
:globe_with_meridians: i18n: Bundle localization into theme

### DIFF
--- a/exampleSite/i18n/en.yaml
+++ b/exampleSite/i18n/en.yaml
@@ -1,5 +1,0 @@
-- id: topics_title
-  translation: Find your answer by subject
-  
-- id: send
-  translation: Send

--- a/exampleSite/i18n/fr.yaml
+++ b/exampleSite/i18n/fr.yaml
@@ -1,5 +1,0 @@
-- id: topics_title
-  translation: Trouvez votre réponse par sujet
-  
-- id: send
-  translation: Envoyer

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,0 +1,5 @@
+---
+- footer:
+    legal: "Find legal information and policies related to {{ $.Site.Params.brand.parent_org_name }}'s digital communications."
+- topics_title: Find your answer by subject
+- send: Send

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -1,0 +1,5 @@
+---
+- footer:
+    legal: "Trouvez des informations juridiques et des politiques liées aux communications numériques de l'{{ $.Site.Params.brand.parent_org_name }}."
+- topics_title: Trouvez votre réponse par sujet
+- send: Envoyer


### PR DESCRIPTION
This commit takes the existing localization files from the example site
and embeds them into a directory where Hugo will look for localizations.
These can be overridden by creating a file of the same name in the Hugo
site, but would require copying all existing translations from the
upstream-provided file. Updates and changes would be manually managed.

This encourages upstreaming of localization efforts and also avoids
snags when a new site is launched with this theme, but the parts of the
theme expecting a `i18n/` configuration render empty.