### PR TITLE
:lipstick: Add custom color to site title for matching logo color

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -333,6 +333,14 @@ pre {
     top: 50px;
 }
 
+nav #site-brand a {
+    color: var(--text-title-color) !important;
+}
+
+nav #site-brand a:focus, nav #site-brand a:hover {
+    color: var(--light-color) !important;
+}
+
 .navbar {
     padding: 0;
 }

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -35,6 +35,7 @@
     --body-color:{{ .Site.Params.body_color }};
     --text-color:{{ .Site.Params.text_color }};
     --text-color-dark:{{ .Site.Params.text_color_dark }};
+    --text-title-color:{{ .Site.Params.text_title_color }};
     --white-color:{{ .Site.Params.white_color }};
     --light-color:{{ .Site.Params.light_color }};
     --font-family:{{ replace .Site.Params.font_family ' ' '+' | title }};

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -1,26 +1,28 @@
 <nav class="navbar navbar-expand-md navbar-dark" style=" {{ if .IsHome }}background-color: transparent{{ else }}background-color: #1CABE2{{ end }}">
   <div class="container px-2 px-md-0">
-      {{ $logo:= site.Params.logo }}
-      {{ $logoWhite:= site.Params.logo_white }}
-      {{ $orgName:= site.Params.brand.parent_org_name }}
-      {{ $orgUrl:= site.Params.brand.parent_org_url }}
-    <a class="navbar-brand px-2" href="{{ if (or $logo $logoWhite) }}{{ $orgUrl }}{{else}}{{ site.BaseURL | relLangURL }}{{ end }}">
-      {{ if (or $logo $logoWhite) }}
-      {{ if .IsHome }}
-      <div class="text-center">
-      <img class="img-fluid d-inline" src="{{if $logoWhite }}{{ $logoWhite | absURL }} {{ else }} {{ $logo | absURL }}{{ end }}"
-        alt="{{ site.Title }}"> <a class="text-white d-block" href="{{ site.BaseURL | relLangURL }}">{{ site.Title }}</a>
+      <div id="site-brand">
+        {{ $logo:= site.Params.logo }}
+        {{ $logoWhite:= site.Params.logo_white }}
+        {{ $orgName:= site.Params.brand.parent_org_name }}
+        {{ $orgUrl:= site.Params.brand.parent_org_url }}
+        <a class="navbar-brand px-2" href="{{ if (or $logo $logoWhite) }}{{ $orgUrl }}{{else}}{{ site.BaseURL | relLangURL }}{{ end }}">
+          {{ if (or $logo $logoWhite) }}
+            {{ if .IsHome }}
+            <div class="text-center">
+              <img class="img-fluid d-inline" src="{{if $logoWhite }}{{ $logoWhite | absURL }} {{ else }} {{ $logo | absURL }}{{ end }}"
+                alt="{{ site.Title }}"> <a class="text-white d-block" href="{{ site.BaseURL | relLangURL }}">{{ site.Title }}</a>
+            </div>
+            {{ else }}
+            <div class="text-center nav-heading">
+              <img class="img-fluid nav-img" src="{{ $logo | absURL }}" alt="{{ site.Title }}">
+              <a class="d-block nav-title" href="{{ site.BaseURL | relLangURL }}">{{ site.Title }}</a>
+            </div>
+            {{ end }}
+          {{ else }}
+          {{ site.Title }}
+          {{ end }}
+        </a>
       </div>
-      {{ else }}
-      <div class="text-center nav-heading">
-      <img class="img-fluid nav-img" src="{{ $logo | absURL }}" alt="{{ site.Title }}"> 
-      <a class="text-white d-block nav-title" href="{{ site.BaseURL | relLangURL }}">{{ site.Title }}</a>
-      </div>
-      {{ end }}
-      {{ else }}
-      {{ site.Title }}
-      {{ end }}
-    </a>
     <button class="navbar-toggler border-0" type="button" data-toggle="collapse" data-target="#navigation"
       aria-controls="navigation" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
This commit adds a new config file value to give the site title in the
navigation bar a contrasting or matching color:

1. `head.html` now reads in `.Site.Params.text_title_color` from Hugo
   config, adds to root stylesheet.
2. Site title in the navigation bar will use the custom text title color
   from the config.
3. `a:focus` and `a:hover` changed to `var(--light-color)`

This addresses feedback from @Idadelveloper in PR #39 about color.