### PR TITLE
:wrench: layouts: Use config-derived metadata for parent organization metadata

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,8 @@
 {{ "<!-- footer -->" | safeHTML }}
 <footer class="section bg-primary p-4">
+  {{ $orgName:= site.Params.brand.parent_org_name }}
+  {{ $orgLegal:= site.Params.brand.parent_org_url_legal }}
+  {{ $orgUrl:= site.Params.brand.parent_org_url }}
   <div class="container">
     <div class="row align-items-center">
     <div class="col-md-3 text-md-left text-center">
@@ -20,14 +23,14 @@
       <div class="col-md-3 text-md-right text-center">
         <ul class="text-white">
           <li class="nav-item">
-              <a class="nav-link text-white font-weight-bold" href="https://www.unicef.org/">UNICEF Global</a>
+              <a class="nav-link text-white font-weight-bold" href="{{ $orgUrl }}">{{ $orgName }}</a>
           </li>
           <li class="nav-item">
               <a class="nav-link text-white font-weight-bold" href="{{ .Site.Params.footer.mainSite }}">{{ .Site.Params.footer.mainSiteName }}</a>
           </li>
           <li class="nav-item">
-              <a class="nav-link text-white font-weight-bold" href="https://www.unicef.org/legal">Legal</a>
-              <p class="h6 text-md-right font-weight-light">Find legal information and policies related to UNICEF's digital communications</p>
+              <a class="nav-link text-white font-weight-bold" href="{{ $orgLegal }}">Legal</a>
+              <p class="h6 text-md-right font-weight-light">{{ i18n "footer.legal" . }}</p>
           </li>
         </ul>
         <ul class="list-inline">

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -2,7 +2,9 @@
   <div class="container px-2 px-md-0">
       {{ $logo:= site.Params.logo }}
       {{ $logoWhite:= site.Params.logo_white }}
-    <a class="navbar-brand px-2" href="{{ if (or $logo $logoWhite) }}https://www.unicef.org/{{else}}{{ site.BaseURL | relLangURL }}{{ end }}">
+      {{ $orgName:= site.Params.brand.parent_org_name }}
+      {{ $orgUrl:= site.Params.brand.parent_org_url }}
+    <a class="navbar-brand px-2" href="{{ if (or $logo $logoWhite) }}{{ $orgUrl }}{{else}}{{ site.BaseURL | relLangURL }}{{ end }}">
       {{ if (or $logo $logoWhite) }}
       {{ if .IsHome }}
       <div class="text-center">
@@ -70,5 +72,5 @@
       {{ end }}
     </div>
   </div>
-    <p class="text-white unicef-glob mx-3">Visit <a href="https://www.unicef.org/" class="text-white">UNICEF Global <i class="fas fa-angle-double-right"></i></a></p>
+    <p class="text-white unicef-glob mx-3">Visit <a href="{{ $orgUrl }}" class="text-white">{{ $orgName }} <i class="fas fa-angle-double-right"></i></a></p>
 </nav>


### PR DESCRIPTION
This commit changes the references to "UNICEF Global" into strings
derived from the Hugo site configuration file. This makes the theme more
general-purpose and easier to adapt for other use cases, like the
SustainOSS open source + design knowledgebase prototype.

It also adds more localization flexibility for text in the footer.

Addressing @Idadelveloper's feedback in PR #39.