### PR TITLE
changed section-tree-nav template name in default.html

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -911,7 +911,7 @@ tbody {
 }
 
 li.sidelist>a {
-    margin-left: 20px;
+    margin-left: 35px;
     margin-bottom: 10px;
     display: block;
     font-size: 20px;

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -35,7 +35,7 @@
           {{ else }}
           <div class="bg-light p-4">
             <ul class="page-list">
-              {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode }}
+              {{ template "default-section-tree-nav" dict "sect" . "currentnode" $currentNode }}
             </ul>
           </div>
           {{ end }}
@@ -124,7 +124,7 @@
 {{ "<!-- /details page -->" | safeHTML }}
 
 <!-- templates -->
-{{ define "section-tree-nav" }}
+{{ define "default-section-tree-nav" }}
 {{ $showvisitedlinks := .showvisitedlinks }}
 {{ $currentNode := .currentnode }}
 {{with .sect}}


### PR DESCRIPTION
In sidebar.html we used section-tree-nav template which is overlapping with the one in the default.html and this is causing the issue #49 . So i changed the template name in default.html. 