### PR TITLE
:lipstick: layouts(navigation): Use consistent color on all pages

### DIFF
--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-md navbar-dark" style=" {{ if .IsHome }}background-color: transparent{{ else }}background-color: #1CABE2{{ end }}">
+<nav class="navbar navbar-expand-md navbar-dark" style=" {{ if .IsHome }}background-color: transparent{{ else }}background-color: {{ site.Params.primary_color }}{{ end }}">
   <div class="container px-2 px-md-0 navigation-bar">
       <div id="site-brand">
         {{ $logo:= site.Params.logo }}
@@ -52,7 +52,7 @@
       </ul>
       <!-- Language List -->
       {{- if site.IsMultiLingual }}
-      <select class="lang-list bg-primary {{ if not .IsHome }}dark mb-3 mb-md-0{{ end }}" id="select-language"
+      <select class="lang-list bg-primary {{ if not .IsHome }}mb-3 mb-md-0{{ end }}" id="select-language"
         onchange="location = this.value;">
         {{ $siteLanguages := site.Languages}}
         {{ $pageLang := .Page.Lang}}


### PR DESCRIPTION
This commit fixes a bug where the UNICEF Blue was hard-coded into the
navigation bar, and changes that hard-coded value to use the primary
color set by the site maintainer in the Hugo config file (`params.`
`primary_color`).

Additionally, I changed the color for the translations options to use a
white color, since it is hard to read when the primary color is a darker
color.