### PR TITLE
Add condition to only show "RA Section" when there's content available

### DIFF
--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -75,40 +75,39 @@
           </nav>
 
           <!-- Related Articles Section -->
-          {{if .Content}}
-          <section class="my-3 py-3" id="related-articles">
-            {{ $c := .Section }}
-            {{ $p := .Params.Categories }}
-            {{ $t := .Params.Title }}
-            {{ $ignore := "alert"}}
-            <h5 class="text-center">Related Articles</h5>
-            <div class="row">
-                {{ range $key, $taxonomy := .Site.Taxonomies.categories }}
-                  {{ if eq $key $p }}
-                  {{ if ne $key $ignore}}
-                    {{ range shuffle ($taxonomy.Pages) | first $.Site.Params.article_count }}
-                      {{ if ne .Title $t }}
-                        <div class="col-sm-4 my-2">
-                          <a href="{{ .Permalink }}">
-                            <div class="card text-center">
-                              {{ if isset .Params "image" }}
-                                <img class="card-img-top" {{ with .Params.image }} src="{{ . }}"{{ end }} alt="{{ .Params.Title }}">
-                              {{ end }}
-                              <div class="card-body">
-                                <h5 class="card-title">{{ .Title }}</h5>
-                                <p class="card-subtitle mb-2 text-muted">{{ .Params.Description }}</p>
-                              </div>
-                            </div>
-                          </a>
+          {{ $c := .Section }}
+          {{ $p := .Params.Categories }}
+          {{ $t := .Params.Title }}
+          {{ $ignore := "alert"}}
+
+          {{ range $key, $taxonomy := .Site.Taxonomies.categories }}
+            {{ if eq $key $p }}
+            {{ if ne $key $ignore}}
+              {{ range shuffle ($taxonomy.Pages) | first $.Site.Params.article_count }}
+                {{ if ne .Title $t }}
+                <section class="my-3 py-3" id="related-articles">
+                  <h5 class="text-center">Related Articles</h5>
+                  <div class="row">
+                    <div class="col-sm-4 my-2">
+                      <a href="{{ .Permalink }}">
+                        <div class="card text-center">
+                          {{ if isset .Params "image" }}
+                            <img class="card-img-top" {{ with .Params.image }} src="{{ . }}"{{ end }} alt="{{ .Params.Title }}">
+                          {{ end }}
+                          <div class="card-body">
+                            <h5 class="card-title">{{ .Title }}</h5>
+                            <p class="card-subtitle mb-2 text-muted">{{ .Params.Description }}</p>
+                          </div>
                         </div>
-                      {{ end }}
-                    {{ end }}
-                  {{ end }}
-                  {{ end }}
+                      </a>
+                    </div>
+                  </div>
+                </section>
                 {{ end }}
-              </div>
-          </section>
-          {{end}}
+              {{ end }}
+            {{ end }}
+            {{ end }}
+          {{ end }}
           <!-- End of related articles section -->
 
           </div>

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -82,9 +82,7 @@
             {{ range $key, $taxonomy := .Site.Taxonomies.categories }}
               {{ if eq $key $p }}
               {{ if ne $key $ignore}}
-              {{ if le $taxonomy.Pages 1 }}
-                  {{ $ignore }}
-                  {{ else }}
+              {{ if not (le $taxonomy.Pages 1) }}
                 <section class="my-3 py-3" id="related-articles">
                   <h5 class="text-center">Related Articles</h5>
                     <div class="row">

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -75,6 +75,7 @@
           </nav>
 
           <!-- Related Articles Section -->
+          {{if .Content}}
           <section class="my-3 py-3" id="related-articles">
             {{ $c := .Section }}
             {{ $p := .Params.Categories }}
@@ -107,6 +108,7 @@
                 {{ end }}
               </div>
           </section>
+          {{end}}
           <!-- End of related articles section -->
 
           </div>

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -82,7 +82,8 @@
             {{ range $key, $taxonomy := .Site.Taxonomies.categories }}
               {{ if eq $key $p }}
               {{ if ne $key $ignore}}
-              {{ if not (le $taxonomy.Pages 1) }}
+              {{ if le $taxonomy.Pages 1 }}
+                {{ else }}
                 <section class="my-3 py-3" id="related-articles">
                   <h5 class="text-center">Related Articles</h5>
                     <div class="row">

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -79,35 +79,38 @@
           {{ $p := .Params.Categories }}
           {{ $t := .Params.Title }}
           {{ $ignore := "alert"}}
-
-          {{ range $key, $taxonomy := .Site.Taxonomies.categories }}
-            {{ if eq $key $p }}
-            {{ if ne $key $ignore}}
-              {{ range shuffle ($taxonomy.Pages) | first $.Site.Params.article_count }}
-                {{ if ne .Title $t }}
+            {{ range $key, $taxonomy := .Site.Taxonomies.categories }}
+              {{ if eq $key $p }}
+              {{ if ne $key $ignore}}
+              {{ if le $taxonomy.Pages 1 }}
+                  {{ $ignore }}
+                  {{ else }}
                 <section class="my-3 py-3" id="related-articles">
                   <h5 class="text-center">Related Articles</h5>
-                  <div class="row">
-                    <div class="col-sm-4 my-2">
-                      <a href="{{ .Permalink }}">
-                        <div class="card text-center">
-                          {{ if isset .Params "image" }}
-                            <img class="card-img-top" {{ with .Params.image }} src="{{ . }}"{{ end }} alt="{{ .Params.Title }}">
+                    <div class="row">
+                          {{ range shuffle ($taxonomy.Pages) | first $.Site.Params.article_count }}
+                            {{ if ne .Title $t }}
+                              <div class="col-sm-4 my-2">
+                                <a href="{{ .Permalink }}">
+                                  <div class="card text-center">
+                                    {{ if isset .Params "image" }}
+                                      <img class="card-img-top" {{ with .Params.image }} src="{{ . }}"{{ end }} alt="{{ .Params.Title }}">
+                                    {{ end }}
+                                    <div class="card-body">
+                                      <h5 class="card-title">{{ .Title }}</h5>
+                                      <p class="card-subtitle mb-2 text-muted">{{ .Params.Description }}</p>
+                                    </div>
+                                  </div>
+                                </a>
+                              </div>
+                            {{ end }}
                           {{ end }}
-                          <div class="card-body">
-                            <h5 class="card-title">{{ .Title }}</h5>
-                            <p class="card-subtitle mb-2 text-muted">{{ .Params.Description }}</p>
-                          </div>
-                        </div>
-                      </a>
                     </div>
-                  </div>
                 </section>
-                {{ end }}
+              {{ end }}
+              {{ end }}
               {{ end }}
             {{ end }}
-            {{ end }}
-          {{ end }}
           <!-- End of related articles section -->
 
           </div>


### PR DESCRIPTION
This commit partially fixes issue #30. The reason I've submitted it as a partial fix is because, the referenced issue doesn't seem to just affects pages inside this repository but also pages inside the cohorts directory located inside this themes' parent directory .i.e. `unicef/inventory`. I will submit a separate pull request on the parent directory to fix the issue there. 