### PR TITLE
🐛 fix: Improved styling of highlight code blocks

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -718,6 +718,7 @@ textarea.form-control {
     font-size: 14px;
 }
 
+/* https://github.com/unicef/inventory-hugo-theme/issues/62 | Fixed line spacing */
 .highlight * {
     margin-bottom: 2px;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -718,6 +718,10 @@ textarea.form-control {
     font-size: 14px;
 }
 
+.highlight * {
+    margin-bottom: 2px;
+}
+
 blockquote {
     font-size: 20px !important;
     color: var(--text-color-dark);

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -35,8 +35,8 @@ markup:
     hl_Lines: ""
     lineAnchors: ""
     lineNoStart: 1
-    lineNos: false
-    lineNumbersInTable: true
+    lineNos: true
+    lineNumbersInTable: false
     noClasses: true
     style: murphy
     tabWidth: 4


### PR DESCRIPTION
Fixes #62

Changes:

This PR resolves the styling issue previously faced while using the `highlight` function to create code blocks.

Screenshot of the change:

<img width="269" alt="image" src="https://user-images.githubusercontent.com/53828745/158440519-ac079ae1-ca91-4ccc-aa64-0162d65f64fb.png">
