### PR TITLE
:recycle: layouts(dpg-report): Reuse download-pdf partial

### DIFF
--- a/layouts/partials/dpg-report.html
+++ b/layouts/partials/dpg-report.html
@@ -20,13 +20,7 @@ $(document).ready(function(){
               {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode}}
               {{ end }}
             {{ end }}
-            {{ if .Content }}
-              {{ if eq .Params.downloadBtn "true" }}
-                <div>
-                    <button class="btn btn-primary btn-block" id="generatePDF" > Get Pdf  </button>
-                </div>
-              {{ end }}
-            {{ end }}
+            {{ partial "download-pdf.html" . }}
           </ul>
         </div>
       </div>


### PR DESCRIPTION
The PDF download button logic was moved into a partial after this layout
was created. This refactors to use the partial and maintain less code.