### PR TITLE
Removed Duplicate Home Link in Footer

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -146,9 +146,6 @@ Languages:
     # --- navigation menu ---
     menu:
       main:
-        - name: Home
-          weight: 10
-          url: .
         - name: FAQ
           weight: 20
           url: faq


### PR DESCRIPTION
Fixes #57
In Footer partial, we have this-
```html
 <li><a class="nav-link text-white" href="{{ site.BaseURL | relLangURL }}">HOME</a></li>
        {{ range site.Menus.main }}
          {{if ne .Name "pages"}}
            <li class="nav-item">
              <a class="nav-link text-white text-uppercase" href="{{ .URL | absLangURL }}">{{ .Name }}</a>
            </li>
          {{ end }}
        {{ end }}
```
In all other upstreams we dont have Home in the Menu array but we do have it in the exampleSite. This is what causing the duplication in exampleSite. So, i have removed it from config file of exampleSite.

@jwflory I contacted the Assignee he said i can proceed.
