### PR TITLE
:bug: :memo: README: Fix link for example site config

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ git submodule update --remote --rebase
 
 ## Configuration
 
-See [`sample_config.yaml`](/sample_config.yaml) for a sample Hugo site using this theme.
+See [`exampleSite/config.yaml`](/exampleSite/config.yaml) for an example Hugo site using this theme.
 
 
 ## Contributing


### PR DESCRIPTION
An example configuration used to be bundled at the top of the repo, but
now it is included as part of the example site used in building this
theme. This commit fixes the broken link in the README.

Closes #79.