### PR TITLE
💄 fix: Added shortcodes for CAUTION and IMPORTANT admonition

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -848,19 +848,19 @@ tbody {
     padding: 10px;
 }
 
-.notices p::before {
+.notices.note p {
+    border-top: 30px solid #6ab0de;
+    background: #e7f2fa;
+}
+
+.notices.note p::before {
     position: absolute;
     top: 2px;
     color: #fff;
     font-family: "themify";
     font-weight: 900;
-    content: "\e717";
-    left: 10px;
-}
-
-.notices.note p {
-    border-top: 30px solid #6ab0de;
-    background: #e7f2fa;
+    content: "\e61d";
+    left: 5px;
 }
 
 .notices.note p::after {
@@ -876,6 +876,16 @@ tbody {
     background: #E6F9E6;
 }
 
+.notices.tip p::before {
+    position: absolute;
+    top: 2px;
+    color: #fff;
+    font-family: "themify";
+    font-weight: 900;
+    content: "\e63a";
+    left: 5px;
+}
+
 .notices.tip p::after {
     content: 'Tip';
     position: absolute;
@@ -887,6 +897,16 @@ tbody {
 .notices.info p {
     border-top: 30px solid #F0B37E;
     background: #FFF2DB;
+}
+
+.notices.info p::before {
+    position: absolute;
+    top: 2px;
+    color: #fff;
+    font-family: "themify";
+    font-weight: 900;
+    content: "\e717";
+    left: 5px;
 }
 
 .notices.info p::after {
@@ -902,8 +922,66 @@ tbody {
     background: #FAE2E2;
 }
 
+.notices.warning p::before {
+    position: absolute;
+    top: 2px;
+    color: #fff;
+    font-family: "themify";
+    font-weight: 900;
+    content: "\e607";
+    left: 5px;
+}
+
 .notices.warning p::after {
     content: 'Warning';
+    position: absolute;
+    top: 2px;
+    color: #fff;
+    left: 2rem;
+}
+
+/*Caution Admonition Shortcode*/
+.notices.caution p {
+    border-top: 30px solid #802392;
+    background: #f7cdff;
+}
+
+.notices.caution p::before {
+    position: absolute;
+    top: 2px;
+    color: #fff;
+    font-family: "themify";
+    font-weight: 900;
+    content: "\e620";
+    left: 5px;
+}
+
+.notices.caution p::after {
+    content: 'Caution';
+    position: absolute;
+    top: 2px;
+    color: #fff;
+    left: 2rem;
+}
+
+/*Important Admonition Shortcode*/
+.notices.important p {
+    border-top: 30px solid #e40046;
+    background: #f7bacc;
+}
+
+.notices.important p::before {
+    position: absolute;
+    top: 2px;
+    color: #fff;
+    font-family: "themify";
+    font-weight: 900;
+    content: "\e6c0";
+    left: 5px;
+}
+
+.notices.important p::after {
+    content: 'Important';
     position: absolute;
     top: 2px;
     color: #fff;

--- a/exampleSite/content/installation/elements/_index.en.md
+++ b/exampleSite/content/installation/elements/_index.en.md
@@ -9,27 +9,33 @@ keywords: [""]
 ---
 
 # Heading 1
+
 ## Heading 2
+
 ### Heading 3
+
 #### Heading 4
+
 ##### Heading 5
+
 ###### Heading 6
 
 <hr>
 
 ##### Emphasis
 
-Emphasis, aka italics, with *asterisks* or _underscores_.
+Emphasis, aka italics, with *asterisks* or *underscores*.
 
-Strong emphasis, aka bold, with **asterisks** or __underscores__.
+Strong emphasis, aka bold, with **asterisks** or **underscores**.
 
-Combined emphasis with **asterisks and _underscores_**.
+Combined emphasis with **asterisks and *underscores***.
 
 Strikethrough uses two tildes. ~~Scratch this.~~
 
 <hr>
 
 ##### Link
+
 [I'm an inline-style link](https://www.google.com)
 
 [I'm an inline-style link with title](https://www.google.com "Google's Homepage")
@@ -40,8 +46,8 @@ Strikethrough uses two tildes. ~~Scratch this.~~
 
 Or leave it empty and use the [link text itself].
 
-URLs and URLs in angle brackets will automatically get turned into links. 
-http://www.example.com or <http://www.example.com> and sometimes 
+URLs and URLs in angle brackets will automatically get turned into links.
+<http://www.example.com> or <http://www.example.com> and sometimes
 example.com (but not on Github, for example).
 
 Some text to show that the reference links can follow later.
@@ -96,6 +102,14 @@ Lorem ipsum dolor sit amet consectetur adipisicing elit. Quam nihil enim maxime 
   This is a simple warning.
 {{< /notice >}}
 
+{{< notice important >}}
+  This is a simple important.
+{{</ notice >}}
+
+{{< notice caution >}}
+  This is a simple caution.
+{{</ notice >}}
+
 <hr>
 
 #### Tab
@@ -126,12 +140,12 @@ Inline `code` has `back-ticks around` it.
 var s = "JavaScript syntax highlighting";
 alert(s);
 ```
- 
+
 ```python
 s = "Python syntax highlighting"
 print s
 ```
- 
+
 ```
 No language indicated, so no syntax highlighting. 
 But let's throw in a <b>tag</b>.
@@ -157,7 +171,6 @@ You can also use raw HTML in your Markdown, and it'll mostly work pretty well.
   <dd>Does *not* work **very** well. Use HTML <em>tags</em>.</dd>
 </dl>
 
-
 <hr>
 
 ##### Tables
@@ -171,7 +184,7 @@ Colons can be used to align columns.
 | zebra stripes | are neat      |    $1 |
 
 There must be at least 3 dashes separating each header cell.
-The outer pipes (|) are optional, and you don't need to make the 
+The outer pipes (|) are optional, and you don't need to make the
 raw Markdown line up prettily. You can also use inline Markdown.
 
 Markdown | Less | Pretty

--- a/exampleSite/content/installation/elements/_index.en.md
+++ b/exampleSite/content/installation/elements/_index.en.md
@@ -9,33 +9,27 @@ keywords: [""]
 ---
 
 # Heading 1
-
 ## Heading 2
-
 ### Heading 3
-
 #### Heading 4
-
 ##### Heading 5
-
 ###### Heading 6
 
 <hr>
 
 ##### Emphasis
 
-Emphasis, aka italics, with *asterisks* or *underscores*.
+Emphasis, aka italics, with *asterisks* or _underscores_.
 
-Strong emphasis, aka bold, with **asterisks** or **underscores**.
+Strong emphasis, aka bold, with **asterisks** or __underscores__.
 
-Combined emphasis with **asterisks and *underscores***.
+Combined emphasis with **asterisks and _underscores_**.
 
 Strikethrough uses two tildes. ~~Scratch this.~~
 
 <hr>
 
 ##### Link
-
 [I'm an inline-style link](https://www.google.com)
 
 [I'm an inline-style link with title](https://www.google.com "Google's Homepage")
@@ -46,8 +40,8 @@ Strikethrough uses two tildes. ~~Scratch this.~~
 
 Or leave it empty and use the [link text itself].
 
-URLs and URLs in angle brackets will automatically get turned into links.
-<http://www.example.com> or <http://www.example.com> and sometimes
+URLs and URLs in angle brackets will automatically get turned into links. 
+http://www.example.com or <http://www.example.com> and sometimes 
 example.com (but not on Github, for example).
 
 Some text to show that the reference links can follow later.
@@ -140,12 +134,12 @@ Inline `code` has `back-ticks around` it.
 var s = "JavaScript syntax highlighting";
 alert(s);
 ```
-
+ 
 ```python
 s = "Python syntax highlighting"
 print s
 ```
-
+ 
 ```
 No language indicated, so no syntax highlighting. 
 But let's throw in a <b>tag</b>.
@@ -171,6 +165,7 @@ You can also use raw HTML in your Markdown, and it'll mostly work pretty well.
   <dd>Does *not* work **very** well. Use HTML <em>tags</em>.</dd>
 </dl>
 
+
 <hr>
 
 ##### Tables
@@ -184,7 +179,7 @@ Colons can be used to align columns.
 | zebra stripes | are neat      |    $1 |
 
 There must be at least 3 dashes separating each header cell.
-The outer pipes (|) are optional, and you don't need to make the
+The outer pipes (|) are optional, and you don't need to make the 
 raw Markdown line up prettily. You can also use inline Markdown.
 
 Markdown | Less | Pretty

--- a/exampleSite/content/installation/elements/_index.fr.md
+++ b/exampleSite/content/installation/elements/_index.fr.md
@@ -9,33 +9,27 @@ keywords: [""]
 ---
 
 # Heading 1
-
 ## Heading 2
-
 ### Heading 3
-
 #### Heading 4
-
 ##### Heading 5
-
 ###### Heading 6
 
 <hr>
 
 ##### Emphasis
 
-Emphasis, aka italics, with *asterisks* or *underscores*.
+Emphasis, aka italics, with *asterisks* or _underscores_.
 
-Strong emphasis, aka bold, with **asterisks** or **underscores**.
+Strong emphasis, aka bold, with **asterisks** or __underscores__.
 
-Combined emphasis with **asterisks and *underscores***.
+Combined emphasis with **asterisks and _underscores_**.
 
 Strikethrough uses two tildes. ~~Scratch this.~~
 
 <hr>
 
 ##### Link
-
 [I'm an inline-style link](https://www.google.com)
 
 [I'm an inline-style link with title](https://www.google.com "Google's Homepage")
@@ -47,7 +41,7 @@ Strikethrough uses two tildes. ~~Scratch this.~~
 Or leave it empty and use the [link text itself].
 
 URLs and URLs in angle brackets will automatically get turned into links.
-<http://www.example.com> or <http://www.example.com> and sometimes
+http://www.example.com or <http://www.example.com> and sometimes
 example.com (but not on Github, for example).
 
 Some text to show that the reference links can follow later.
@@ -110,6 +104,7 @@ Lorem ipsum dolor sit amet consectetur adipisicing elit. Quam nihil enim maxime 
   This is a simple caution.
 {{</ notice >}}
 
+
 <hr>
 
 #### Tab
@@ -147,7 +142,7 @@ print s
 ```
 
 ```
-No language indicated, so no syntax highlighting. 
+No language indicated, so no syntax highlighting.
 But let's throw in a <b>tag</b>.
 ```
 
@@ -170,6 +165,7 @@ You can also use raw HTML in your Markdown, and it'll mostly work pretty well.
   <dt>Markdown in HTML</dt>
   <dd>Does *not* work **very** well. Use HTML <em>tags</em>.</dd>
 </dl>
+
 
 <hr>
 

--- a/exampleSite/content/installation/elements/_index.fr.md
+++ b/exampleSite/content/installation/elements/_index.fr.md
@@ -9,27 +9,33 @@ keywords: [""]
 ---
 
 # Heading 1
+
 ## Heading 2
+
 ### Heading 3
+
 #### Heading 4
+
 ##### Heading 5
+
 ###### Heading 6
 
 <hr>
 
 ##### Emphasis
 
-Emphasis, aka italics, with *asterisks* or _underscores_.
+Emphasis, aka italics, with *asterisks* or *underscores*.
 
-Strong emphasis, aka bold, with **asterisks** or __underscores__.
+Strong emphasis, aka bold, with **asterisks** or **underscores**.
 
-Combined emphasis with **asterisks and _underscores_**.
+Combined emphasis with **asterisks and *underscores***.
 
 Strikethrough uses two tildes. ~~Scratch this.~~
 
 <hr>
 
 ##### Link
+
 [I'm an inline-style link](https://www.google.com)
 
 [I'm an inline-style link with title](https://www.google.com "Google's Homepage")
@@ -40,8 +46,8 @@ Strikethrough uses two tildes. ~~Scratch this.~~
 
 Or leave it empty and use the [link text itself].
 
-URLs and URLs in angle brackets will automatically get turned into links. 
-http://www.example.com or <http://www.example.com> and sometimes 
+URLs and URLs in angle brackets will automatically get turned into links.
+<http://www.example.com> or <http://www.example.com> and sometimes
 example.com (but not on Github, for example).
 
 Some text to show that the reference links can follow later.
@@ -96,6 +102,14 @@ Lorem ipsum dolor sit amet consectetur adipisicing elit. Quam nihil enim maxime 
   This is a simple warning.
 {{< /notice >}}
 
+{{< notice important >}}
+  This is a simple important.
+{{</ notice >}}
+
+{{< notice caution >}}
+  This is a simple caution.
+{{</ notice >}}
+
 <hr>
 
 #### Tab
@@ -126,12 +140,12 @@ Inline `code` has `back-ticks around` it.
 var s = "JavaScript syntax highlighting";
 alert(s);
 ```
- 
+
 ```python
 s = "Python syntax highlighting"
 print s
 ```
- 
+
 ```
 No language indicated, so no syntax highlighting. 
 But let's throw in a <b>tag</b>.
@@ -157,7 +171,6 @@ You can also use raw HTML in your Markdown, and it'll mostly work pretty well.
   <dd>Does *not* work **very** well. Use HTML <em>tags</em>.</dd>
 </dl>
 
-
 <hr>
 
 ##### Tables
@@ -171,7 +184,7 @@ Colons can be used to align columns.
 | zebra stripes | are neat      |    $1 |
 
 There must be at least 3 dashes separating each header cell.
-The outer pipes (|) are optional, and you don't need to make the 
+The outer pipes (|) are optional, and you don't need to make the
 raw Markdown line up prettily. You can also use inline Markdown.
 
 Markdown | Less | Pretty


### PR DESCRIPTION
Fixes #64 and #66 

Changes:

The PR adds shortcodes for `CAUTION` and `IMPORTANT` admonition blocks.

Screenshot of the change:

<img width="646" alt="image" src="https://user-images.githubusercontent.com/53828745/160779232-e8f010c7-63db-46d9-a061-cd09dffe2e0a.png">

To test if the new admonitions are properly working, the following code can be used: 



```
{{< notice important >}}
  This is a simple important.
{{</ notice >}}

{{< notice caution >}}
  This is a simple caution.
{{</ notice >}}
```