### PR TITLE
📝 docs: Added table shortcode in Elements page

### DIFF
--- a/exampleSite/content/installation/elements/_index.en.md
+++ b/exampleSite/content/installation/elements/_index.en.md
@@ -170,7 +170,9 @@ You can also use raw HTML in your Markdown, and it'll mostly work pretty well.
 
 ##### Tables
 
-Colons can be used to align columns.
+To make a table, create each column's header with three or more hyphens (---), and separate each column with pipes (|).
+
+{{<table "table">}}
 
 | Tables        | Are           | Cool  |
 | ------------- |:-------------:| -----:|
@@ -178,14 +180,20 @@ Colons can be used to align columns.
 | col 2 is      | centered      |   $12 |
 | zebra stripes | are neat      |    $1 |
 
-There must be at least 3 dashes separating each header cell.
-The outer pipes (|) are optional, and you don't need to make the 
-raw Markdown line up prettily. You can also use inline Markdown.
+{{</table>}}
+
+You can align text in the columns to the left, right, or center by adding a colon (:) to the left, right, or on both side of the hyphens within the header row.
+
+{{<table "table">}}
 
 Markdown | Less | Pretty
 --- | --- | ---
 *Still* | `renders` | **nicely**
 1 | 2 | 3
+
+{{</table>}}
+
+To automatically generate the table by simply assigning values to the cells, use the [Markdown Table Generator Tool](https://www.tablesgenerator.com/markdown_tables).
 
 <hr>
 

--- a/exampleSite/content/installation/elements/_index.fr.md
+++ b/exampleSite/content/installation/elements/_index.fr.md
@@ -171,7 +171,9 @@ You can also use raw HTML in your Markdown, and it'll mostly work pretty well.
 
 ##### Tables
 
-Colons can be used to align columns.
+To make a table, create each column's header with three or more hyphens (---), and separate each column with pipes (|).
+
+{{<table "table">}}
 
 | Tables        | Are           | Cool  |
 | ------------- |:-------------:| -----:|
@@ -179,14 +181,20 @@ Colons can be used to align columns.
 | col 2 is      | centered      |   $12 |
 | zebra stripes | are neat      |    $1 |
 
-There must be at least 3 dashes separating each header cell.
-The outer pipes (|) are optional, and you don't need to make the
-raw Markdown line up prettily. You can also use inline Markdown.
+{{</table>}}
+
+You can align text in the columns to the left, right, or center by adding a colon (:) to the left, right, or on both side of the hyphens within the header row.
+
+{{<table "table">}}
 
 Markdown | Less | Pretty
 --- | --- | ---
 *Still* | `renders` | **nicely**
 1 | 2 | 3
+
+{{</table>}}
+
+To automatically generate the table by simply assigning values to the cells, use the [Markdown Table Generator Tool](https://www.tablesgenerator.com/markdown_tables).
 
 <hr>
 


### PR DESCRIPTION
Fixes #71

Changes:

This PR adds `table` shortcodes to the existing tables along with the documentation to the [elements page](https://unicef.github.io/inventory-hugo-theme/installation/elements/). 

Screenshot of the change:

<img width="960" alt="image" src="https://user-images.githubusercontent.com/53828745/162000254-68ed8442-fd16-47a8-a921-64b0ee292d35.png">
