### PR TITLE
Improve navigation and wayfinding(#95)

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -127,7 +127,7 @@ Languages:
   en:
     languageName: en
     languageCode: en-us
-    weight: 1
+    weight: 2
     home: Home
     copyright: "Copyright &copy; 2020-2022 a Hugo theme by [UNICEF Office of Innovation](https://www.unicef.org/innovation/)"
     params:
@@ -147,6 +147,9 @@ Languages:
     # --- navigation menu ---
     menu:
       main:
+        - name: Home
+          weight: 10
+          url: .
         - name: FAQ
           weight: 20
           url: faq

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -127,7 +127,7 @@ Languages:
   en:
     languageName: en
     languageCode: en-us
-    weight: 2
+    weight: 1
     home: Home
     copyright: "Copyright &copy; 2020-2022 a Hugo theme by [UNICEF Office of Innovation](https://www.unicef.org/innovation/)"
     params:

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,37 +5,50 @@
   {{ $orgUrl:= site.Params.brand.parent_org_url }}
   <div class="container">
     <div class="row align-items-center">
-    <div class="col-md-3 text-md-left text-center">
-       <ul>
-        <li><a class="nav-link text-white" href="{{ site.BaseURL | relLangURL }}">HOME</a></li>
-        {{ range site.Menus.main }}
+      <div class="col-md-3 text-md-left text-center">
+        <ul>
+          {{ range site.Menus.main }}
           {{if ne .Name "pages"}}
             <li class="nav-item">
               <a class="nav-link text-white text-uppercase" href="{{ .URL | absLangURL }}">{{ .Name }}</a>
             </li>
+          {{else if .HasChildren }}
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle text-white text-uppercase" href="#" role="button" data-toggle="dropdown"
+                aria-haspopup="true" aria-expanded="false"> {{ .Name }} 
+              </a>
+              <div class="dropdown-menu">
+                {{ range .Children }}
+                  <a class="dropdown-item" href="{{ .URL | absLangURL }}">{{ .Name }}</a>
+                {{ end }}
+              </div>
+            </li>
           {{ end }}
-        {{ end }}
-       </ul>
+          {{ end }}
+
+        </ul>
       </div>
       <div class="col-md-6 text-md-center text-center">
-       <p class="mb-md-0 mb-4 text-white">{{ .Site.Params.footer.description | markdownify }}</p>
+        <p class="mb-md-0 mb-4 text-white">{{ .Site.Params.footer.description | markdownify }}</p>
       </div>
       <div class="col-md-3 text-md-right text-center">
         <ul class="text-white">
           <li class="nav-item">
-              <a class="nav-link text-white font-weight-bold" href="{{ $orgUrl }}">{{ $orgName }}</a>
+            <a class="nav-link text-white font-weight-bold" href="{{ $orgUrl }}">{{ $orgName }}</a>
           </li>
           <li class="nav-item">
-              <a class="nav-link text-white font-weight-bold" href="{{ .Site.Params.footer.mainSite }}">{{ .Site.Params.footer.mainSiteName }}</a>
+            <a class="nav-link text-white font-weight-bold" href="{{ .Site.Params.footer.mainSite }}">{{
+              .Site.Params.footer.mainSiteName }}</a>
           </li>
           <li class="nav-item">
-              <a class="nav-link text-white font-weight-bold" href="{{ $orgLegal }}">Legal</a>
-              <p class="h6 text-md-right font-weight-light">{{ i18n "footer.legal" . }}</p>
+            <a class="nav-link text-white font-weight-bold" href="{{ $orgLegal }}">Legal</a>
+            <p class="h6 text-md-right font-weight-light">{{ i18n "footer.legal" . }}</p>
           </li>
         </ul>
         <ul class="list-inline">
           {{ range .Site.Params.social }}
-          <li class="list-inline-item"><a class="text-color d-inline-block p-2 text-white" href="{{ .link | safeURL }}" aria-label="{{ .name }}"><i class="{{ .icon }}"></i></a></li>
+          <li class="list-inline-item"><a class="text-color d-inline-block p-2 text-white" href="{{ .link | safeURL }}"
+              aria-label="{{ .name }}"><i class="{{ .icon }}"></i></a></li>
           {{ end }}
         </ul>
       </div>


### PR DESCRIPTION
### Summary

The feature Creates a new "Home" category and "Pages" category in the header and footer respectively to improve navigation and make the site more user friendly (improve user-experience). Before these were added, on selecting English, the Home category in the header was not available. And while at the footer of the page, if a user wanted to access the "Pages" dropdown options, they would have to scroll all the way up.

### Details
The picture below shows how the page was before changes were made:

![3AFBEC79-8E69-4DB9-A297-47EE3CD438D9](https://user-images.githubusercontent.com/84882370/163198264-31f9c1cd-687f-4434-aedc-48b90facb356.jpeg) 

The picture below shows how the page was after changes were made:

![DF3A9E3D-7D54-43A9-B0BE-16305F7CF1AB](https://user-images.githubusercontent.com/84882370/163198595-76cc65be-d556-47ce-a545-f510e2e81141.jpeg)

### Outcome

With the addition of the Home category, users who select English as their preferred language can easily navigate their and the Pages category allows users go their without going through the stress of scrolling from the end of the site to its header. With these, the website is more user friendly.