### PR TITLE
:sparkles: layouts: Add redirect layout and docs (closes #69)

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -19,6 +19,13 @@ enableGitInfo: true
 googleAnalytics: ""
 
 
+# --- security settings ---
+
+security:
+  exec:
+    allow: ['^dart-sass-embedded$', '^go$', '^npx$', '^postcss$', '^asciidoctor$']
+
+
 # --- markup settings ---
 
 markup:

--- a/exampleSite/content/features/redirect.en.adoc
+++ b/exampleSite/content/features/redirect.en.adoc
@@ -1,0 +1,27 @@
+---
+title: Page redirects
+description: Create a special page that redirects the user to a URL hosted on an external website.
+categories: features
+tag: ["layouts"]
+downloadBtn: true
+
+---
+
+The UNICEF Inventory theme includes a feature that allows you to redirect the user to another website.
+Sometimes, a page hosted in your site is moved to another website.
+While Hugo allows you to create https://gohugo.io/content-management/urls/#aliases[aliases] that redirects one page to another in the same site, it is not possible to redirect a page to an external site.
+These *page redirects* solve that problem.
+
+To create a page redirect, define the layout `type` and `redirectUrl` in the page front-matter:
+
+{{< highlight yaml >}}
+---
+title: UNICEF Office of Innovation
+description: The Office of Innovation uses technology to address the biggest challenges facing children today.
+type: redirect
+redirectUrl: https://www.unicef.org/innovation/
+
+---
+{{< /highlight >}}
+
+When the user visits this page on the Hugo site, they are redirected to the `unicef.org` website after a five-second pause.

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,6 +1,9 @@
 ---
 - buttons:
     edit_page: Edit this Page
+- layouts:
+    redirect_title: This page has moved
+    redirect_body: This page has moved. You will be redirected in five seconds. Please update any bookmarks. If you are not redirected, please follow the link below.
 - footer:
     legal: "Find legal information and policies related to {{ $.Site.Params.brand.parent_org_name }}'s digital communications."
 - topics_title: Find your answer by subject

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -1,6 +1,9 @@
 ---
 - buttons:
     edit_page: Modifier cette page
+- layouts:
+    redirect_title: Cette page a déménagé
+    redirect_body: Cette page a déménagé. Vous allez être redirigé en cinq secondes. Veuillez mettre à jour tous les signets. Si vous n'êtes pas redirigé, veuillez suivre le lien ci-dessous.
 - footer:
     legal: "Trouvez des informations juridiques et des politiques liées aux communications numériques de l'{{ $.Site.Params.brand.parent_org_name }}."
 - topics_title: Trouvez votre réponse par sujet

--- a/layouts/redirect/single.html
+++ b/layouts/redirect/single.html
@@ -1,0 +1,16 @@
+{{ define "main" }}
+
+{{ "<!-- redirect -->" | safeHTML }}
+<!-- If the page is a redirect layout, use a 301 Redirect to the desired URL defined in the page front-matter. -->
+<meta http-equiv="refresh" content="5; url='{{ .Params.redirectURL }}'"/>
+
+<section class="section">
+  <div class="container text-center">
+    <h2 class="section-title text-dark">{{ i18n "layouts.redirect_title" }}</h2>
+    <p>{{ i18n "layouts.redirect_body" }}</p>
+    <h4><a href="{{ .Params.redirectURL }}">{{ .Params.redirectURL }}</a></h4>
+  </div>
+</section>
+{{ "<!-- /redirect -->" | safeHTML }}
+
+{{ end }}


### PR DESCRIPTION
This commit adds a new type of layout, a redirect, to the theme. A
redirect layout is similar to the existing Hugo aliases, except instead
of being limited to internal redirect (i.e. redirecting one page to
another page in the same site), we can now redirect a user to a page
hosted externally on another site.

The motivation for this is so that we can ensure that user experience is
not disrupted when content is moved from one site to somewhere else. In
our case, we want to move content about data science into the UNICEF
Data Science & A.I. Toolkit and some of our developer-focused content
into the Software Development Toolkit. This new feature enables that
transition to happen smoothly for anyone who has an old URL bookmarked
or linked somewhere else. See unicef/inventory#128 for more context.

Closes unicef/inventory-hugo-theme#69.

![Screenshot of new documentation that explains how to use the feature.](https://user-images.githubusercontent.com/4721034/174903038-e26925a8-d47e-470a-bc87-761f6abd5d17.png "Screenshot of new documentation that explains how to use the feature.")

![Screenshot of the redirect page in action, before it redirects the user to the new URL.](https://user-images.githubusercontent.com/4721034/174903626-e19e7df9-cc53-49be-84d2-d2c77896399c.png "Screenshot of the redirect page in action, before it redirects the user to the new URL.")