### PR TITLE
:memo: README: Add attribution note for Data Science & A.I. Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Forked from Dot, a Hugo theme by ThemeFisher.
 
 * [UNICEF Open Source Inventory](https://unicef.github.io/inventory/)
 * [UNICEF Coach Cards](https://unicef.github.io/coach/)
-* [UNICEF Drone DPG Toolkit](https://unicef.github.io/drone-4sdgtoolkit/)
-* [UNICEF Software Development Toolkit](https://unicef.github.io/ooi-toolkit-software/)
 * [SustainOSS Design & UX knowledgebase](https://sustainers.github.io/design/)
+* Toolkits:
+    * [UNICEF Data Science & A.I. Toolkit](https://unicef.github.io/ooi-toolkit-ds/)
+    * [UNICEF Drones Toolkit](https://unicef.github.io/drone-4sdgtoolkit/)
+    * [UNICEF Software Development Toolkit](https://unicef.github.io/ooi-toolkit-software/)
 
 
 ## Installation


### PR DESCRIPTION
Reorder some of the attribution credits into a list of toolkits. Add the
UNICEF Data Science & A.I. Toolkit as another example of a site using
this theme.

ref: https://github.com/unicef/ooi-toolkit-ds