### PR TITLE
:new: :memo: Add contributing category & key stakeholders (closes #127)

### DIFF
--- a/exampleSite/content/contributing/_index.en.md
+++ b/exampleSite/content/contributing/_index.en.md
@@ -1,0 +1,7 @@
+---
+title: Contributing
+icon: "ti-comments"
+description: Information for contributors to the UNICEF Inventory theme or UNICEF Toolkits using this theme.
+type: docs
+
+---

--- a/exampleSite/content/contributing/stakeholders.en.adoc
+++ b/exampleSite/content/contributing/stakeholders.en.adoc
@@ -1,0 +1,39 @@
+---
+title: Key stakeholders
+description: Definition of key stakeholders for the UNICEF Inventory theme and UNICEF Toolkits.
+categories: contributing
+tag: ["unicef"]
+downloadBtn: true
+
+---
+:toc:
+
+This page summarizes and defines the key stakeholders for the UNICEF Inventory theme and UNICEF Toolkits.
+
+
+[[toolkit-open-source]]
+== Open Source Inventory (toolkit)
+
+Found at https://unicef.github.io/inventory/[unicef.github.io/inventory/].
+There are three key stakeholders for this toolkit:
+
+.Open Source Inventory stakeholder comparison
+|===
+|Stakeholder|Team background|Purpose|Needs
+
+|https://www.unicefinnovationfund.org/[*UNICEF Venture Fund team*]
+|Mostly non-software
+|To view progress of startup companies in achieving open source-related goals and milestones.
+|Get quick information about a cohort and specific companies of a cohort, see their progress towards meeting the Digital Public Goods Standard
+
+|*Start-up companies supported by UNICEF Venture Fund*
+|Software
+|To receive guidance on open source-related topics and focuses related to the Digital Public Good Standard.
+|Discover information about DPG Standard indicators, see examples from other open source communities for assignment work, and get questions answered about how to work in an open source-friendly way
+
+|*UNICEF open source developers*
+|Mix of software and non-software
+|To learn more about about open source best practices.
+|Discover information about open source communities and learn about how to work in more transparent and collaborative ways
+
+|===


### PR DESCRIPTION
This commit adds a new "Contributing" category to the site and
initializes it with a "Key stakeholders" page. The stakeholders page is
part of a user story and defines the primary users for the Open Source
Inventory toolkit.

This page is part of a gradual effort of converting the example site for
the UNICEF Inventory theme into more comprehensive and useful
documentation. Eventually, more content may be migrated to live in this
category as a common reference for several toolkits.

Closes #127. Part of #89.

![Screenshot of the rendered article in a local developer preview built with Hugo.](https://user-images.githubusercontent.com/4721034/175857870-fee86f55-e015-476a-b3fa-6823d03e3b83.png "Screenshot of the rendered article in a local developer preview built with Hugo.")