### PR TITLE
Added description to the content

### DIFF
--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -33,16 +33,19 @@
 
         <div class="p-lg-5 p-3 bg-white">
           <h2 id="title">{{ .Title }}</h2>
-          {{if .Params.author}}
-          <span class="text-dark">{{ .Params.author }}</span>
-          {{if .Params.authorEmail}}
-           <span>-</span>
-          <a href="mailto:{{ .Params.authorEmail }}">{{.Params.authorEmail}}</a>
-          <br/>
-          {{end}}
-          {{end}}
-          {{ if .Content }}
-          {{.Description}}
+          <div class="container">
+            {{if .Params.author}}
+            <span class="text-dark">{{ .Params.author }}</span>
+            {{if .Params.authorEmail}}
+             <span>-</span>
+            <a href="mailto:{{ .Params.authorEmail }}">{{.Params.authorEmail}}</a>
+            {{end}}
+            {{end}}
+          </div>
+          <div class="container">
+            {{ if .Content }}
+            {{.Description}}
+          </div>
           <div class="content mt-5">{{ partial "header-link.html" .Content }}</div>
           {{ else }}
           {{.Description}}

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -38,6 +38,7 @@
           {{if .Params.authorEmail}}
            <span>-</span>
           <a href="mailto:{{ .Params.authorEmail }}">{{.Params.authorEmail}}</a>
+          <br/>
           {{end}}
           {{end}}
           {{ if .Content }}

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -41,8 +41,10 @@
           {{end}}
           {{end}}
           {{ if .Content }}
+          {{.Description}}
           <div class="content mt-5">{{ partial "header-link.html" .Content }}</div>
           {{ else }}
+          {{.Description}}
           <div class="bg-light p-4">
             <ul class="page-list">
               {{ template "default-section-tree-nav" dict "sect" . "currentnode" $currentNode }}


### PR DESCRIPTION
This fix is useful for dpg indicators restructure.
If there is no content in a particular DPG indicator then this change will show the description of that page there.

Results:
![image](https://user-images.githubusercontent.com/85057583/179858471-d852ef32-c90b-4cce-9030-6c90b9c97bf1.png)
