### PR TITLE
DPG indicators layout update

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -15,14 +15,16 @@
           <h2 class="section-title">{{ i18n "topics_title" | safeHTML }}</h2>
         </div>
         {{ "<!-- topic-item -->" | safeHTML }}
-        {{ range (where .Site.Pages "Type" "docs") }}
+        {{ range .Site.Pages  }}
+        {{if or (eq .Type "docs") (eq .Type "dpg-standard")}}
         <div class="col-lg-4 col-sm-6 mb-4">
           <a href="{{ .Permalink }}" class="px-4 py-5 bg-white shadow text-center d-block match-height cardLink">
             {{ with .Params.icon}}<i class="{{.}} icon text-primary d-block mb-4"></i>{{end}}
             <h3 class="mb-3 mt-0">{{ .Title }}</h3>
-            {{with .Params.description}}<p class="mb-0">{{. | markdownify}}</p>{{end}}
+            {{with .Params.description}}<p class="mb-0">{{. | markdownify}}</p>{{ end }}
           </a>
         </div>
+        {{ end }}
         {{ end }}
       </div>
     </div>


### PR DESCRIPTION
This commit changes the site homepage layout so that any page with the
layout "dpg-standard" will also show on the homepage, along with the
pages tagged as "type: docs" in the post front-matter.

Closes unicef/inventory-hugo-theme#128.