### PR TITLE
Added displaying Page Tags functionality

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -171,6 +171,26 @@ h6,
     color: var(--white-color);
 }
 
+/* page tags */
+.page-tags-flex {
+    display: flex;
+    flex-direction: row;
+}
+
+.page-tags {
+    background-color: #1CABE2;
+    justify-content: center;
+    align-items: center;
+    height: fit-content;
+    width: fit-content;
+    padding: 3px 10px;
+    border-radius: 0.25rem;
+    white-space: normal;
+    overflow: hidden;
+    color: #fff;
+    font-size: 13px;
+    margin: 10px 0 10px 20px;
+}
 
 /* preloader */
 

--- a/exampleSite/content/about/lorem-ipsum.en.adoc
+++ b/exampleSite/content/about/lorem-ipsum.en.adoc
@@ -2,7 +2,7 @@
 title: "Example: Lorem ipsum"
 description: A page used for quickly seeing several different features and markup of the UNICEF Inventory theme.
 categories: about
-tag: ["content", "developers"]
+tags: ["content", "developers"]
 downloadBtn: true
 # search related keywords
 keywords: [""]

--- a/exampleSite/content/contributing/stakeholders.en.adoc
+++ b/exampleSite/content/contributing/stakeholders.en.adoc
@@ -2,7 +2,7 @@
 title: Key stakeholders
 description: Definition of key stakeholders for the UNICEF Inventory theme and UNICEF Toolkits.
 categories: contributing
-tag: ["unicef"]
+tags: ["unicef"]
 downloadBtn: true
 
 ---

--- a/exampleSite/content/features/_template.en.adoc
+++ b/exampleSite/content/features/_template.en.adoc
@@ -3,7 +3,7 @@ draft: true
 title: Feature name
 description: One sentence to describe the feature and how it impacts users.
 categories: features
-tag: [""]
+tags: [""]
 downloadBtn: true
 
 ---

--- a/exampleSite/content/features/admonitions/_index.en.adoc
+++ b/exampleSite/content/features/admonitions/_index.en.adoc
@@ -2,7 +2,7 @@
 title: Admonitions
 description: Call out specific information and details in an article using an admonition.
 categories: features
-tag: ["content"]
+tags: ["content"]
 downloadBtn: true
 
 ---

--- a/exampleSite/content/features/author-byline/_index.en.adoc
+++ b/exampleSite/content/features/author-byline/_index.en.adoc
@@ -2,7 +2,7 @@
 title: Author byline
 description: Identify the author and author contact information of a page.
 categories: features
-tag: ["content"]
+tags: ["content"]
 downloadBtn: true
 
 ---

--- a/exampleSite/content/features/brand-identity/_index.en.adoc
+++ b/exampleSite/content/features/brand-identity/_index.en.adoc
@@ -2,7 +2,7 @@
 title: Brand & identity
 description: Change text and visual appearance to better represent the brand and identity of the site owner.
 categories: features
-tag: ["design"]
+tags: ["design"]
 downloadBtn: true
 
 ---

--- a/exampleSite/content/features/code-highlighting/_index.en.adoc
+++ b/exampleSite/content/features/code-highlighting/_index.en.adoc
@@ -2,7 +2,7 @@
 title: Code highlighting
 description: Render code with a syntax highlighter.
 categories: features
-tag: ["content"]
+tags: ["content"]
 downloadBtn: true
 
 ---

--- a/exampleSite/content/features/redirect/_index.en.adoc
+++ b/exampleSite/content/features/redirect/_index.en.adoc
@@ -2,7 +2,7 @@
 title: Page redirects
 description: Create a special page that redirects the user to a URL hosted on an external website.
 categories: features
-tag: ["layouts"]
+tags: ["layouts"]
 downloadBtn: true
 
 ---

--- a/exampleSite/content/features/tab-tables/_index.en.adoc
+++ b/exampleSite/content/features/tab-tables/_index.en.adoc
@@ -2,7 +2,7 @@
 title: Tab tables
 description: Tab tables organize complex information into tabbed sections within an article.
 categories: features
-tag: ["content"]
+tags: ["content"]
 downloadBtn: true
 
 ---

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -33,6 +33,9 @@
 
         <div class="p-lg-5 p-3 bg-white">
           <h2 id="title">{{ .Title }}</h2>
+          <div>
+            {{ partial "page-tags.html" . }}
+          </div>
           <div class="container">
             {{if .Params.author}}
             <span class="text-dark">{{ .Params.author }}</span>

--- a/layouts/partials/page-tags.html
+++ b/layouts/partials/page-tags.html
@@ -1,0 +1,7 @@
+<div class="page-tags-flex">
+    {{ range $tag := .Params.Tag }}
+    <div class="page-tags">
+        {{ $tag }}
+    </div>
+    {{ end }}
+</div>

--- a/layouts/partials/page-tags.html
+++ b/layouts/partials/page-tags.html
@@ -1,5 +1,5 @@
 <div class="page-tags-flex">
-    {{ range $tag := .Params.Tag }}
+    {{ range $tag := .Params.tags }}
     <div class="page-tags">
         {{ $tag }}
     </div>


### PR DESCRIPTION
Fixes #123 

### Functionality Added:
- [x] Added a new partial template for Page Tags to be displayed on articles.

### Screenshot of the Changes
<img width="960" alt="image" src="https://user-images.githubusercontent.com/53828745/189398807-12187024-dfd3-4ff9-8d68-5d06f3042e84.png">

### Adding Page Tags to Article pages
Tags can be added by specifying tags in the page description. For Example: 
```
title: Brand & identity
description: Change text and visual appearance to better represent the brand and identity of the site owner.
categories: features
tag: ["design", "brand", "identity"]
downloadBtn: true
```