### PR TITLE
:bug: layouts(index): Show "team" type posts on index page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,7 +16,7 @@
         </div>
         {{ "<!-- topic-item -->" | safeHTML }}
         {{ range .Site.Pages  }}
-        {{if or (eq .Type "docs") (eq .Type "dpg-standard")}}
+        {{ if or (eq .Type "docs") (eq .Type "dpg-standard") (eq .Type "team") }}
         <div class="col-lg-4 col-sm-6 mb-4">
           <a href="{{ .Permalink }}" class="px-4 py-5 bg-white shadow text-center d-block match-height cardLink">
             {{ with .Params.icon}}<i class="{{.}} icon text-primary d-block mb-4"></i>{{end}}


### PR DESCRIPTION
This commit shows the "team" template type on the index page of the site. The use case for this change is so that the total cohorts view still appears when navigating to `/inventory/cohorts/` and it also appears as its own category on the site homepage alongside other topics.

This contributes to unblocking unicef/inventory#136.