### PR TITLE
:art: :lipstick: layouts(index): Reduce padding around index text

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -273,7 +273,7 @@ h4:hover a {
 
 .section,
 section.main-section {
-    padding-top: calc(250px - 4vw);
+    padding-top: 10vh;
 }
 
 @media (max-width: 768px) {

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,14 +1,14 @@
 {{ define "main" }}
 
-  {{ if .Content }}
-  <section class="section text-center pb-0">
-    <div class="container">
-    {{ .Content }}
-    </div>
-  </section>
-  {{ end }}
-  {{ "<!-- topics -->" | safeHTML }}
   <section class="section">
+    {{ if .Content }}
+      {{ "<!-- index page text -->" | safeHTML }}
+      <div class="container text-center pb-5">
+        {{ .Content }}
+      </div>
+      {{ "<!-- /index page text -->" | safeHTML }}
+    {{ end }}
+    {{ "<!-- topics -->" | safeHTML }}
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-12 text-center">


### PR DESCRIPTION
This commit moves the index page text (if provided in the Hugo site) into the `<section>` tag for the main topics. It uses a Bootstrap container inside of the `<section>` and therefore exists inside of the styling rules for the section instead of working against its styling.

This reduces the large amount of whitespace that exists between the search bar section of the site and the topics. It is easier to realize there is more content.

Related to unicef/inventory-hugo-theme#154.

![Desktop view of the UNICEF Open Source Inventory using index page text and the changes included in this PR.](https://user-images.githubusercontent.com/4721034/194386777-53ebe24f-8bbc-4007-b20a-f09518f6090f.png "Desktop view of the UNICEF Open Source Inventory using index page text and the changes included in this PR.")

![Tablet view of the UNICEF Inventory theme example site using the changes included in this PR.](https://user-images.githubusercontent.com/4721034/194386887-d93bdb16-504a-44d1-8b64-94f2c5eae749.png "Tablet view of the UNICEF Inventory theme example site using the changes included in this PR.")